### PR TITLE
Add rezepte.lol app share

### DIFF
--- a/android/src/main/java/de/gematik/ti/erp/app/prescription/detail/ui/PrescriptionDetailScreen.kt
+++ b/android/src/main/java/de/gematik/ti/erp/app/prescription/detail/ui/PrescriptionDetailScreen.kt
@@ -93,6 +93,7 @@ import de.gematik.ti.erp.app.analytics.trackPrescriptionDetailPopUps
 import de.gematik.ti.erp.app.analytics.trackScreenUsingNavEntry
 import de.gematik.ti.erp.app.core.LocalAnalytics
 import de.gematik.ti.erp.app.core.LocalAuthenticator
+import de.gematik.ti.erp.app.prescription.detail.ui.model.AppLinkPrescription
 import de.gematik.ti.erp.app.prescription.detail.ui.model.PrescriptionData
 import de.gematik.ti.erp.app.prescription.detail.ui.model.PrescriptionDetailsNavigationScreens
 import de.gematik.ti.erp.app.prescription.model.SyncedTaskData
@@ -118,8 +119,11 @@ import de.gematik.ti.erp.app.utils.compose.SpacerXXLarge
 import de.gematik.ti.erp.app.utils.compose.dateWithIntroductionString
 import de.gematik.ti.erp.app.utils.compose.handleIntent
 import de.gematik.ti.erp.app.utils.compose.provideEmailIntent
+import de.gematik.ti.erp.app.utils.dateIsoText
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -237,35 +241,6 @@ fun PrescriptionDetailsScreen(
     }
 }
 
-@Serializable
-data class AppLinkPrescription(
-    val patient: String?,
-    val prescriber: String?,
-    val description: String?,
-    val prescribedOn: String?,
-    val taskUrl: String,
-    val emoji: String?
-)
-
-private val AllowedPrescriptionEmojis = listOf(
-    "\uD83D\uDE23",    // 😣
-    "\uD83D\uDE35",    // 😵
-    "\uD83D\uDE35\u200D\uD83D\uDCAB",    // 😵‍💫
-    "\uD83E\uDD22",    // 🤢
-    "\uD83E\uDD2E",    // 🤮
-    "\uD83E\uDD27",    // 🤧
-    "\uD83D\uDE37",    // 😷
-    "\uD83E\uDD12",    // 🙂
-    "\uD83E\uDD15",    // 🙅
-    "\uD83E\uDE7A",    // 🥺
-    "\uD83D\uDC89",    // 💉
-    "\uD83D\uDC8A",    // 💊
-    "\uD83E\uDDA0",    // 🦠
-    "\uD83C\uDF21",    // 🌡️
-    "\uD83E\uDDEA",    // 🧪
-    "\uD83E\uDDEB"     // 🧫
-)
-
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 private fun PrescriptionDetailsWithScaffold(
@@ -350,17 +325,16 @@ private fun PrescriptionDetailsWithScaffold(
                                 prescriber = null,
                                 description = null,
                                 prescribedOn = null,
-                                taskUrl = taskUrl,
-                                emoji = AllowedPrescriptionEmojis.random()
+                                taskUrl = taskUrl
                             )
                         is PrescriptionData.Synced ->
                             AppLinkPrescription(
                                 patient = prescription.patient.name,
                                 prescriber = prescription.practitioner.name,
                                 description = prescription.name,
-                                prescribedOn = prescription.authoredOn,
-                                taskUrl = taskUrl,
-                                emoji = AllowedPrescriptionEmojis.random()
+                                // UTC is safe here; most people get their prescriptions during the day
+                                prescribedOn = dateIsoText(prescription.authoredOn, zone = TimeZone.UTC),
+                                taskUrl = taskUrl
                             )
                     }.let { Base64.encodeToString(Json.encodeToString(it).toByteArray(), Base64.URL_SAFE) }
 

--- a/android/src/main/java/de/gematik/ti/erp/app/prescription/detail/ui/model/Share.kt
+++ b/android/src/main/java/de/gematik/ti/erp/app/prescription/detail/ui/model/Share.kt
@@ -1,0 +1,32 @@
+package de.gematik.ti.erp.app.prescription.detail.ui.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AppLinkPrescription(
+    val patient: String?,
+    val prescriber: String?,
+    val description: String?,
+    val prescribedOn: String?,
+    val taskUrl: String,
+    val emoji: String = AppLinkAllowedPrescriptionEmojis.random()
+)
+
+private val AppLinkAllowedPrescriptionEmojis = listOf(
+    "\uD83D\uDE23",    // 😣
+    "\uD83D\uDE35",    // 😵
+    "\uD83D\uDE35\u200D\uD83D\uDCAB",    // 😵‍💫
+    "\uD83E\uDD22",    // 🤢
+    "\uD83E\uDD2E",    // 🤮
+    "\uD83E\uDD27",    // 🤧
+    "\uD83D\uDE37",    // 😷
+    "\uD83E\uDD12",    // 🙂
+    "\uD83E\uDD15",    // 🙅
+    "\uD83E\uDE7A",    // 🥺
+    "\uD83D\uDC89",    // 💉
+    "\uD83D\uDC8A",    // 💊
+    "\uD83E\uDDA0",    // 🦠
+    "\uD83C\uDF21",    // 🌡️
+    "\uD83E\uDDEA",    // 🧪
+    "\uD83E\uDDEB"     // 🧫
+)

--- a/android/src/main/java/de/gematik/ti/erp/app/utils/DateTime.kt
+++ b/android/src/main/java/de/gematik/ti/erp/app/utils/DateTime.kt
@@ -50,6 +50,11 @@ fun dateTimeMediumText(instant: Instant, zone: TimeZone = TimeZone.currentSystem
         .toJavaLocalDateTime()
         .format(dateTimeMediumFormatter)
 
+fun dateIsoText(instant: Instant, zone: TimeZone = TimeZone.currentSystemDefault()): String =
+    instant.toLocalDateTime(zone)
+        .toJavaLocalDateTime()
+        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"))
+
 private val YearMonthPattern = DateTimeFormatter.ofPattern("MMMM yyyy")
 private val MonthPattern = DateTimeFormatter.ofPattern("yyyy")
 


### PR DESCRIPTION
Hey E-Rezept Team!

We from [Let's Prescribe](https://letsprescribe.company/) have noticed the missing share feature in the official E-Prescription app and would like to make a proposal to address this gap. This PR aims to add a new share functionality to the app's detail page's top bar, enabling users to share e-prescriptions securely using our app [rezepte.lol](https://rezepte.lol).

With this enhancement, users will have the ability to share their e-prescriptions using end-to-end encryption to another user who has the same app installed. Our app [rezepte.lol](https://rezepte.lol) handles all the necessary technical aspects of this process.

To ensure a seamless user experience, it might be necessary to include additional dialogs that explain the outlinking process to our app before actually opening or sending the link.

Please note that we weren't able to test the code in this PR since some API keys are missing for the startup of the E-Rezept app.

**What is rezepte.lol?**
[rezepte.lol](https://rezepte.lol) is an app for securely sharing e-prescriptions from one user to another end-to-end encrypted

**How does the app to app sharing work?**
As of today, we published a documentation for this process (in german): [Vorankündigung: Teilen von eRezepten in die rezepte.lol App hinein](https://github.com/orgs/rezepte-lol/discussions/4)

The new app enabling this feature is also available within the [beta channel](https://play.google.com/apps/testing/lol.rezepte).

**We are happy to hear from you!**

Best, Tobias 😊
